### PR TITLE
Add FixedDataTableRowDelegate API for mouse events listeners on row.

### DIFF
--- a/build_helpers/buildAPIDocs.sh
+++ b/build_helpers/buildAPIDocs.sh
@@ -23,6 +23,11 @@ var FILES_TO_READ = [
     path: path.join(PROJECT_ROOT, 'src/FixedDataTableColumnGroup.react.js'),
     name: 'ColumnGroup',
     markdownFileName: 'ColumnGroupAPI.md'
+  },
+  {
+    path: path.join(PROJECT_ROOT, 'src/FixedDataTableRowDelegate.react.js'),
+    name: 'Row',
+    markdownFileName: 'RowAPI.md'
   }
 ];
 

--- a/docs/RowAPI.md
+++ b/docs/RowAPI.md
@@ -1,0 +1,145 @@
+<!-- File generated from "src/FixedDataTableRowDelegate.react.js" -->
+`Row` (component)
+=================
+
+Component that defines the attributes of table column.
+
+Props
+-----
+
+### `onClick`
+
+Callback that is called when a row is clicked.
+
+type: `func`
+
+
+### `onContextMenu`
+
+Callback that is called when context menu is going to open
+above a row.
+
+type: `func`
+
+
+### `onDoubleClick`
+
+Callback that is called when a row is double clicked.
+
+type: `func`
+
+
+### `onDrag`
+
+Callback that is called when a row is being dragged.
+
+type: `func`
+
+
+### `onDragEnd`
+
+Callback that is called when a drag operation is being ended
+above a row.
+
+type: `func`
+
+
+### `onDragEnter`
+
+Callback that is called when a dragged target enters a row.
+
+type: `func`
+
+
+### `onDragExit`
+
+Callback that is called when a dragged target exits a row.
+
+type: `func`
+
+
+### `onDragLeave`
+
+Callback that is called when a dragged target leaves a row.
+
+type: `func`
+
+
+### `onDragOver`
+
+Callback that is called when a dragged target is being dragged
+over a row.
+
+type: `func`
+
+
+### `onDragStart`
+
+Callback that is called when the user starts dragging a row.
+
+type: `func`
+
+
+### `onDrop`
+
+Callback that is called when a dragged target is dropped on a row.
+
+type: `func`
+
+
+### `onMouseDown`
+
+Callback that is called mouse down event happens above a row.
+
+type: `func`
+
+
+### `onMouseEnter`
+
+Callback that is called when the mouse enters a row.
+
+type: `func`
+
+
+### `onMouseLeave`
+
+Callback that is called when the mouse leaves a row.
+
+type: `func`
+
+
+### `onMouseMove`
+
+Callback that is called when the mouse is moving above a row.
+
+type: `func`
+
+
+### `onMouseOut`
+
+Callback that is called when the mouse moves out of a row.
+
+type: `func`
+
+
+### `onMouseOver`
+
+Callback that is called when the mouse is moving above a row.
+
+type: `func`
+
+
+### `onMouseUp`
+
+Callback that is called when mouse up event happens above a row.
+
+type: `func`
+
+
+### `draggable`
+
+If specified, attribute `draggable={bool}` will be added to
+nodes of rows.
+
+type: `bool`
+

--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -545,6 +545,7 @@ var FixedDataTable = React.createClass({
         showLastRowBorder={!state.footerHeight}
         width={state.width}
         rowPositionGetter={this._scrollHelper.getRowPosition}
+        rowSettings={state.rowSettings}
       />
     );
   },
@@ -677,6 +678,7 @@ var FixedDataTable = React.createClass({
     }
 
     var children = [];
+    var rowDelegate = null;
 
     ReactChildren.forEach(props.children, (child, index) => {
       if (child == null) {
@@ -684,12 +686,23 @@ var FixedDataTable = React.createClass({
       }
       invariant(
         child.type.__TableColumnGroup__ ||
-        child.type.__TableColumn__,
+        child.type.__TableColumn__ ||
+        child.type.__TableRowDelegate__,
         'child type should be <FixedDataTableColumn /> or ' +
-        '<FixedDataTableColumnGroup />'
+        '<FixedDataTableColumnGroup /> or' +
+        '<FixedDataTableRowDelegate />'
       );
+      if (child.type.__TableRowDelegate__) {
+        rowDelegate = child;
+      } else {
       children.push(child);
+      }
     });
+
+    var rowSettings = {};
+    if (rowDelegate) {
+      rowSettings = rowDelegate.props;
+    }
 
     var useGroupHeader = false;
     if (children.length && children[0].type.__TableColumnGroup__) {
@@ -803,6 +816,8 @@ var FixedDataTable = React.createClass({
 
       ...columnInfo,
       ...props,
+
+      rowSettings,
 
       columnResizingData,
       firstRowIndex,

--- a/src/FixedDataTableBufferedRows.react.js
+++ b/src/FixedDataTableBufferedRows.react.js
@@ -43,6 +43,7 @@ var FixedDataTableBufferedRows = React.createClass({
     scrollableColumns: PropTypes.array.isRequired,
     showLastRowBorder: PropTypes.bool,
     width: PropTypes.number.isRequired,
+    rowSettings: PropTypes.object
   },
 
   getInitialState() /*object*/ {
@@ -129,7 +130,7 @@ var FixedDataTableBufferedRows = React.createClass({
         rowIndex === props.rowsCount - 1 && props.showLastRowBorder;
 
       this._staticRowArray[i] =
-        <FixedDataTableRow
+        <FixedDataTableRow {...props.rowSettings}
           key={i}
           index={rowIndex}
           data={rowGetter(rowIndex)}

--- a/src/FixedDataTableRoot.js
+++ b/src/FixedDataTableRoot.js
@@ -26,8 +26,10 @@ if (__DEV__) {
 var FixedDataTable = require('FixedDataTable.react');
 var FixedDataTableColumn = require('FixedDataTableColumn.react');
 var FixedDataTableColumnGroup = require('FixedDataTableColumnGroup.react');
+var FixedDataTableRowDelegate = require('FixedDataTableRowDelegate.react');
 
 var FixedDataTableRoot = {
+  Row: FixedDataTableRowDelegate,
   Column: FixedDataTableColumn,
   ColumnGroup: FixedDataTableColumnGroup,
   Table: FixedDataTable,

--- a/src/FixedDataTableRow.react.js
+++ b/src/FixedDataTableRow.react.js
@@ -137,14 +137,34 @@ var FixedDataTableRowImpl = React.createClass({
         rowIndex={this.props.index}
       />;
 
+    var optionalProps = {};
+    if ('draggable' in this.props) {
+      optionalProps.draggable = this.props.draggable;
+    }
+
     return (
       <div
         className={joinClasses(className, this.props.className)}
         onClick={this.props.onClick ? this._onClick : null}
+        onContextMenu={this.props.onContextMenu ? this._onContextMenu : null}
+        onDoubleClick={this.props.onDoubleClick ? this._onDoubleClick : null}
+        onDrag={this.props.onDrag ? this._onDrag : null}
+        onDragEnd={this.props.onDragEnd ? this._onDragEnd : null}
+        onDragEnter={this.props.onDragEnter ? this._onDragEnter : null}
+        onDragExit={this.props.onDragExit ? this._onDragExit : null}
+        onDragLeave={this.props.onDragLeave ? this._onDragLeave : null}
+        onDragOver={this.props.onDragOver ? this._onDragOver : null}
+        onDragStart={this.props.onDragStart ? this._onDragStart : null}
+        onDrop={this.props.onDrop ? this._onDrop : null}
         onMouseDown={this.props.onMouseDown ? this._onMouseDown : null}
         onMouseEnter={this.props.onMouseEnter ? this._onMouseEnter : null}
         onMouseLeave={this.props.onMouseLeave ? this._onMouseLeave : null}
-        style={style}>
+        onMouseMove={this.props.onMouseMove ? this._onMouseMove : null}
+        onMouseOut={this.props.onMouseOut ? this._onMouseOut : null}
+        onMouseOver={this.props.onMouseOver ? this._onMouseOver : null}
+        onMouseUp={this.props.onMouseUp ? this._onMouseUp : null}
+        style={style}
+        {...optionalProps}>
         <div className={cx('fixedDataTableRow/body')}>
           {fixedColumns}
           {scrollableColumns}
@@ -180,6 +200,46 @@ var FixedDataTableRowImpl = React.createClass({
     this.props.onClick(event, this.props.index, this.props.data);
   },
 
+  _onContextMenu(/*object*/ event) {
+    this.props.onContextMenu(event, this.props.index, this.props.data);
+  },
+
+  _onDoubleClick(/*object*/ event) {
+    this.props.onDoubleClick(event, this.props.index, this.props.data);
+  },
+
+  _onDrag(/*object*/ event) {
+    this.props.onDrag(event, this.props.index, this.props.data);
+  },
+
+  _onDragEnd(/*object*/ event) {
+    this.props.onDragEnd(event, this.props.index, this.props.data);
+  },
+
+  _onDragEnter(/*object*/ event) {
+    this.props.onDragEnter(event, this.props.index, this.props.data);
+  },
+
+  _onDragExit(/*object*/ event) {
+    this.props.onDragExit(event, this.props.index, this.props.data);
+  },
+
+  _onDragLeave(/*object*/ event) {
+    this.props.onDragLeave(event, this.props.index, this.props.data);
+  },
+
+  _onDragOver(/*object*/ event) {
+    this.props.onDragOver(event, this.props.index, this.props.data);
+  },
+
+  _onDragStart(/*object*/ event) {
+    this.props.onDragStart(event, this.props.index, this.props.data);
+  },
+
+  _onDrop(/*object*/ event) {
+    this.props.onDrop(event, this.props.index, this.props.data);
+  },
+
   _onMouseDown(/*object*/ event) {
     this.props.onMouseDown(event, this.props.index, this.props.data);
   },
@@ -191,6 +251,23 @@ var FixedDataTableRowImpl = React.createClass({
   _onMouseLeave(/*object*/ event) {
     this.props.onMouseLeave(event, this.props.index, this.props.data);
   },
+
+  _onMouseMove(/*object*/ event) {
+    this.props.onMouseMove(event, this.props.index, this.props.data);
+  },
+
+  _onMouseOut(/*object*/ event) {
+    this.props.onMouseOut(event, this.props.index, this.props.data);
+  },
+
+  _onMouseOver(/*object*/ event) {
+    this.props.onMouseOver(event, this.props.index, this.props.data);
+  },
+
+  _onMouseUp(/*object*/ event) {
+    this.props.onMouseUp(event, this.props.index, this.props.data);
+  },
+
 });
 
 var FixedDataTableRow = React.createClass({

--- a/src/FixedDataTableRow.react.js
+++ b/src/FixedDataTableRow.react.js
@@ -139,7 +139,9 @@ var FixedDataTableRowImpl = React.createClass({
 
     var optionalProps = {};
     if ('draggable' in this.props) {
-      optionalProps.draggable = this.props.draggable;
+      optionalProps.draggable = typeof this.props.draggable === 'function' ?
+        !!this.props.draggable(this.props.index, this.props.data) :
+        this.props.draggable;
     }
 
     return (

--- a/src/FixedDataTableRowDelegate.react.js
+++ b/src/FixedDataTableRowDelegate.react.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule FixedDataTableRowDelegate.react
+ * @typechecks
+ */
+
+var React = require('React');
+
+var PropTypes = React.PropTypes;
+
+/**
+ * Component that defines the attributes of table column.
+ */
+var FixedDataTableRowDelegate = React.createClass({
+  statics: {
+    __TableRowDelegate__: true
+  },
+
+  propTypes: {
+    /**
+     * Callback that is called when a row is clicked.
+     */
+    onClick: PropTypes.func,
+
+    /**
+     * Callback that is called when context menu is going to open
+     * above a row.
+     */
+    onContextMenu: PropTypes.func,
+
+    /**
+     * Callback that is called when a row is double clicked.
+     */
+    onDoubleClick: PropTypes.func,
+
+    /**
+     * Callback that is called when a row is being dragged.
+     */
+    onDrag: PropTypes.func,
+
+    /**
+     * Callback that is called when a drag operation is being ended
+     * above a row.
+     */
+    onDragEnd: PropTypes.func,
+
+    /**
+     * Callback that is called when a dragged target enters a row.
+     */
+    onDragEnter: PropTypes.func,
+
+    /**
+     * Callback that is called when a dragged target exits a row.
+     */
+    onDragExit: PropTypes.func,
+
+    /**
+     * Callback that is called when a dragged target leaves a row.
+     */
+    onDragLeave: PropTypes.func,
+
+    /**
+     * Callback that is called when a dragged target is being dragged
+     * over a row.
+     */
+    onDragOver: PropTypes.func,
+
+    /**
+     * Callback that is called when the user starts dragging a row.
+     */
+    onDragStart: PropTypes.func,
+
+    /**
+     * Callback that is called when a dragged target is dropped on a row.
+     */
+    onDrop: PropTypes.func,
+
+    /**
+     * Callback that is called mouse down event happens above a row.
+     */
+    onMouseDown: PropTypes.func,
+
+    /**
+     * Callback that is called when the mouse enters a row.
+     */
+    onMouseEnter: PropTypes.func,
+
+    /**
+     * Callback that is called when the mouse leaves a row.
+     */
+    onMouseLeave: PropTypes.func,
+
+    /**
+     * Callback that is called when the mouse is moving above a row.
+     */
+    onMouseMove: PropTypes.func,
+
+    /**
+     * Callback that is called when the mouse moves out of a row.
+     */
+    onMouseOut: PropTypes.func,
+
+    /**
+     * Callback that is called when the mouse is moving above a row.
+     */
+    onMouseOver: PropTypes.func,
+
+    /**
+     * Callback that is called when mouse up event happens above a row.
+     */
+    onMouseUp: PropTypes.func,
+
+    /**
+     * If specified, attribute `draggable={bool}` will be added to
+     * nodes of rows.
+     */
+    draggable: PropTypes.bool,
+
+  },
+
+  render() {
+    if (__DEV__) {
+      throw new Error(
+        'Component <FixedDataTableRowDelegate /> should never render'
+      );
+    }
+    return null;
+  },
+});
+
+module.exports = FixedDataTableRowDelegate;

--- a/src/FixedDataTableRowDelegate.react.js
+++ b/src/FixedDataTableRowDelegate.react.js
@@ -117,10 +117,13 @@ var FixedDataTableRowDelegate = React.createClass({
     onMouseUp: PropTypes.func,
 
     /**
-     * If specified, attribute `draggable={bool}` will be added to
+     * If specified, attribute `draggable={bool|function}` will be added to
      * nodes of rows.
+     *
+     * If provided function, row index and row data will be passed in as
+     * parameters, and supposed to return a bool.
      */
-    draggable: PropTypes.bool,
+    draggable: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
 
   },
 


### PR DESCRIPTION
I'm using FixedDataTable to make a OS X Finder like component, which needs to support drag & drop on rows.
So I added a new API called RowDelegate, via which event listeners can be attached to rows as the similar way as Column:

```
<Table>
    <Row onDragStart={this._onDragStart}
        onDrop={this._onDrop}
</Table>
```

All its props will be attached to FixedDataTableRowImpl, and can be overrided by Table's onRowXXX props.
