### PR TITLE
added a bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+    "name": "fixed-data-table",
+    "description": "A React table component designed to allow presenting thousands of rows of data.",
+    "version": "0.1.2",
+    "main": [
+        "./dist/fixed-data-table.css",
+        "./dist/fixed-data-table.js"
+    ],
+    "license": "MIT",
+    "dependencies": {
+        "react": ">=0.12.0 <0.14.0"
+    }
+}


### PR DESCRIPTION
I'm not seeing a bower.json file in the source. Here's a minimal one that will allow devs to pull fixed-data-table into their own projects.
