### PR TITLE
Fix issue where table doesn't render rows when relaxing filter with zero results

### DIFF
--- a/src/FixedDataTableScrollHelper.js
+++ b/src/FixedDataTableScrollHelper.js
@@ -239,12 +239,17 @@ class FixedDataTableScrollHelper {
    * brings that row to top of viewport with that offset
    */
   scrollToRow(/*number*/ rowIndex, /*number*/ offset) /*object*/ {
-    rowIndex = clamp(0, rowIndex, this._rowCount - 1);
-    offset = clamp(-this._storedHeights[rowIndex], offset, 0);
-    var firstRow = this._rowOffsets.get(rowIndex);
-    return this.scrollTo(
-      firstRow.value - this._storedHeights[rowIndex] - offset
-    );
+    if (this._rowCount === 0) {
+      return this.scrollTo(0);
+    }
+    else {
+      rowIndex = clamp(0, rowIndex, this._rowCount - 1);
+      offset = clamp(-this._storedHeights[rowIndex], offset, 0);
+      var firstRow = this._rowOffsets.get(rowIndex);
+      return this.scrollTo(
+        firstRow.value - this._storedHeights[rowIndex] - offset
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
This issue only presents when you attempt to scroll to row 0 via `scrollToRow` when there's no rows. This could be seen as a misuse of the `scrollToRow` parameter, if so feel free to close.
#### Steps to reproduce
1. Populate a table with some content, but _not_ enough for the scroll bar to appear.
2. Apply a filter which removes all rows, at the same time scroll to row 0.
3. Remove the filter again.
#### Expected

The results displayed during step 1 should be displayed again.
#### Actual

No results rendered.
#### Cause

It stems from an `NaN` target scroll position making its way into `FixedDataTableScrollHelper.scrollTo`, called from `scrollToRow`, when there are no rows to render. This `NaN` value is then stored in `this._position` which causes the table not to update when there are rows to render again (minus the scroll bar).

In `scrollToRow` the line: `rowIndex = clamp(0, rowIndex, this._rowCount - 1);` returns -1 when there's no rows (max ends up less than min in the clamp) , which triggers a subsequent lookup to return `undefined`. I did try keeping the index a 0 in this case but that led to other issues.
#### Fix

I've put a check in `scrollToRow` to ensure we only ever scroll to 0 when there's no rows, which seems to do the trick. Or simply don't set the `scrollToRow` parameter when there's no rows.
