### PR TITLE
Throw a warning if no footer data is provided while user intends to render the footer row

### DIFF
--- a/src/FixedDataTable.react.js
+++ b/src/FixedDataTable.react.js
@@ -31,6 +31,7 @@ var emptyFunction = require('emptyFunction');
 var invariant = require('invariant');
 var shallowEqual = require('shallowEqual');
 var translateDOMPositionXY = require('translateDOMPositionXY');
+var warning = require('warning');
 
 var {PropTypes} = React;
 var ReactChildren = React.Children;
@@ -481,6 +482,11 @@ var FixedDataTable = React.createClass({
 
     var footer = null;
     if (state.footerHeight) {
+      warning(
+        'footerDataGetter' in props || 'footerData' in props,
+        "Either 'footerDataGetter' or 'footerData' should be provided to render the footer row."
+      );
+
       var footerData = props.footerDataGetter
         ? props.footerDataGetter()
         : props.footerData;

--- a/src/stubs/warning.js
+++ b/src/stubs/warning.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2014-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule warning
+ */
+
+"use strict";
+
+var emptyFunction = require('emptyFunction');
+
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+var warning = emptyFunction;
+
+if (__DEV__) {
+  warning = function(condition, format, ...args) {
+    if (format === undefined) {
+      throw new Error(
+        '`warning(condition, format, ...args)` requires a warning ' +
+        'message argument'
+      );
+    }
+
+    if (format.indexOf('Failed Composite propType: ') === 0) {
+      return; // Ignore CompositeComponent proptype check.
+    }
+
+    if (!condition) {
+      var argIndex = 0;
+      var message = 'Warning: ' + format.replace(/%s/g, () => args[argIndex++]);
+      if (typeof console !== 'undefined') {
+        console.error(message);
+      }
+      try {
+        // --- Welcome to debugging React ---
+        // This error was thrown as a convenience so that you can use this stack
+        // to find the callsite that caused this warning to fire.
+        throw new Error(message);
+      } catch(x) {}
+    }
+  };
+}
+
+module.exports = warning;


### PR DESCRIPTION
I have encountered the same issue as in issue #172 (footerRenderer does not seem to work), where I assumed as long as `footerRenderer()` is provided, the footer row would be rendered anyhow. This is not documented, however it could be confusing.
