### PR TITLE
Workaround for "Invalid Calling Object" error in IE when using Webpack Hot Loader

### DIFF
--- a/src/vendor_upstream/core/requestAnimationFramePolyfill.js
+++ b/src/vendor_upstream/core/requestAnimationFramePolyfill.js
@@ -28,6 +28,9 @@ var requestAnimationFrame =
       callback(Date.now());
     }, timeDelay);
   };
+  
+// Webpack Hot Loader IE bug fix  
+requestAnimationFrame = requestAnimationFrame.bind(window);  
 
 // Works around a rare bug in Safari 6 where the first request is never invoked.
 requestAnimationFrame(emptyFunction);


### PR DESCRIPTION
Calling `requestAnimationFrame` alias function in IE with Webpack Hot Loader causes "Invalid Calling Object" error.
