### PR TITLE
Added role=row for FixedDataTable Row.

### DIFF
--- a/dist/fixed-data-table.js
+++ b/dist/fixed-data-table.js
@@ -4680,6 +4680,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        style: style },
 	      React.createElement(
 	        'div',
+            role: "row",
 	        { className: cx('fixedDataTableRowLayout/body') },
 	        fixedColumns,
 	        scrollableColumns,


### PR DESCRIPTION
In order to enable Accessibility for the FixedDataTable, I have added role=row on the FixedDataTableRow element. This is very helpful for narrator and other screen readers. 

In order to create a grid-role element, my table is wrapped in another div on my client and that has the grid-role. 
