### PR TITLE
adjust size of table to screen size (proposal)

### DIFF
--- a/src/css/layout/fixedDataTableLayout.css
+++ b/src/css/layout/fixedDataTableLayout.css
@@ -13,7 +13,8 @@
   border-style: solid;
   border-width: 1px;
   box-sizing: border-box;
-  overflow: hidden;
+  max-width: 100%;
+  overflow: auto;
   position: relative;
 }
 
@@ -42,7 +43,8 @@
 }
 
 .fixedDataTableLayout/rowsContainer {
-  overflow: hidden;
+  max-width: 100%;
+  overflow: auto;
   position: relative;
 }
 


### PR DESCRIPTION
This adds scroll bars to the table, and makes the specified width a max width.

I use this on my website; I specified the width in React code, and users with large monitors can use the very large table effectively. If they are offsite on their mobile, they can still access the table by scrolling through the rows and columns.

Perhaps this should be a configurable option; if I had a hint towards a good approach, I would be happy to implement it.
