### PR TITLE
Fix property "scrollToRow" not working for the added rows when "rowsCount" grows

### DIFF
--- a/src/FixedDataTableNew.react.js
+++ b/src/FixedDataTableNew.react.js
@@ -762,15 +762,6 @@ var FixedDataTable = React.createClass({
       scrollY = scrollState.position;
     }
 
-    if (this._rowToScrollTo !== undefined) {
-      scrollState =
-        this._scrollHelper.scrollRowIntoView(this._rowToScrollTo);
-      firstRowIndex = scrollState.index;
-      firstRowOffset = scrollState.offset;
-      scrollY = scrollState.position;
-      delete this._rowToScrollTo;
-    }
-
     var groupHeaderHeight = useGroupHeader ? props.groupHeaderHeight : 0;
 
     if (oldState && props.rowsCount !== oldState.rowsCount) {
@@ -794,6 +785,15 @@ var FixedDataTable = React.createClass({
       scrollY = scrollState.position;
     } else if (oldState && props.rowHeightGetter !== oldState.rowHeightGetter) {
       this._scrollHelper.setRowHeightGetter(props.rowHeightGetter);
+    }
+
+    if (this._rowToScrollTo !== undefined) {
+      scrollState =
+        this._scrollHelper.scrollRowIntoView(this._rowToScrollTo);
+      firstRowIndex = scrollState.index;
+      firstRowOffset = scrollState.offset;
+      scrollY = scrollState.position;
+      delete this._rowToScrollTo;
     }
 
     var columnResizingData;


### PR DESCRIPTION
Currently, inside the `_calculateState()` method of the `FixedDataTable` class, the implementation code first applies the updated value of the 'scrollToRow' property (if it has changed). And then the code checks if the number of rows in the table has changed – in that case a new scroll helper object is created. In the practical cases, when the table grows (thus, the row count increases) and it is required to scroll the updated table to a row beyond the old row count (i.e. beyond the old max row index), the above code flow does not work properly:

First, the new value of `scrollToRow` is passed to the previously created scroll helper object. Which cannot correctly calculate the new index and offset for the first visible table row as the `scrollToRow` index passed to it lies beyond the (old) row count that that helper object knows of. And it is only after that, that the code creates a new scroll helper for the updated row count. But at that point, the values for the first visible row index and its offset have already been updated (incorrectly) and are not properly reflecting the row index requested with 'scrollToRow'.

This bug makes it very inconvenient to use 'scrollToRow' with dynamically changing table data – an ugly workaround has to be applied in the external code, to force re-rendering the table once again immediately after rendering it with an updated number of rows. Thus, resulting in totally unnecessary re-render cycles (not to mention that figuring out that workaround is not that obvious at all, without diving deep into the implementation code).

The fix is simple here: The code block for checking and applying the value of 'scrollToRow' (if that value has changed) needs to be invoked _after_ the code block responsible for the internal state updates and the creation of new scroll helper, being done on a changed number of table rows.

Hopefully, we can see a quick update of the official repository with this fix included. @zpao, thanks for your efforts on reviving the official support for this project!
