### PR TITLE
Use "rowIndex" instead of "i" to key rows

### DIFF
--- a/src/FixedDataTableBufferedRows.react.js
+++ b/src/FixedDataTableBufferedRows.react.js
@@ -129,7 +129,7 @@ var FixedDataTableBufferedRows = React.createClass({
 
       this._staticRowArray[i] =
         <FixedDataTableRow
-          key={i}
+          key={rowIndex}
           isScrolling={props.isScrolling}
           index={rowIndex}
           width={props.width}


### PR DESCRIPTION
Using `i` as a key for the `FixedDataTableRow` sometimes resulted in incorrect cells being rendered in the table after scrolling. I found using the `rowIndex` as a key fixed this bug.
