### PR TITLE
Added hack for properly rendering new dynamic row heights

### DIFF
--- a/dist/fixed-data-table.js
+++ b/dist/fixed-data-table.js
@@ -1,5 +1,5 @@
 /**
- * FixedDataTable v0.6.3 
+ * FixedDataTable v0.6.3
  *
  * Copyright (c) 2015, Facebook, Inc.
  * All rights reserved.
@@ -904,6 +904,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	     */
 	    rowClassNameGetter: PropTypes.func,
 
+			/**
+		     * Added boolean to determine if the fix for dynamic row heights is necessary
+		     */
+				hasDynamicRowHeight: PropTypes.bool,
 	    /**
 	     * Pixel height of the column group header.
 	     */
@@ -1499,6 +1503,14 @@ return /******/ (function(modules) { // webpackBootstrap
 	      delete this._columnToScrollTo;
 	    }
 
+			if(props.hasDynamicRowHeight){
+				//Change for correcting dynamic row height update bug
+				//This forces each row height to recalculate before table height is determined, otherwise it will use stale row heights
+				for(var i=0;i<props.rowsCount;i++){
+					this._scrollHelper.getRowPosition(i);
+				}
+			}
+			
 	    var useMaxHeight = props.height === undefined;
 	    var height = Math.round(useMaxHeight ? props.maxHeight : props.height);
 	    var totalHeightReserved = props.footerHeight + props.headerHeight + groupHeaderHeight + 2 * BORDER_HEIGHT;
@@ -5951,7 +5963,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 * of patent rights can be found in the PATENTS file in the same directory.
 	 *
 	 * @providesModule PrefixIntervalTree
-	 * 
+	 *
 	 * @typechecks
 	 */
 
@@ -6426,7 +6438,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	 *
 	 * @providesModule shallowEqual
 	 * @typechecks
-	 * 
+	 *
 	 */
 
 	'use strict';


### PR DESCRIPTION
This repo seems abandoned, but I figured I'd leave this here in case it helps someone else with a similar issue.  The problem this fix is for is the table not resizing correctly when new data is sent in, which would cause the row heights from rowHeightGetter to return different heights for the same rows.

The problem is basically that fixed-data-table keeps a cache of row heights internally (inside of the helper class FixedDataTableScrollHelper), and it calculates the table height values using a stale cache once you start filtering the table.  The fixed-data-table component gives you the hook for getRowHeight, but only expects you to use it for initially variable row heights not for row heights that change over time.  The height for the table is calculated and set before the render call, and the proper row heights are only calculated during the render call of a child component (FixedDataTableBufferedRows).  

I got around this problem by adding a loop around line 1506 that runs through every row and uses the FixedDataTableScrollHelper function getRowPosition to get the position of every row.  Calling this function also has the side-effect of updating the row height cache, so having this loop before the table height gets calculated means that it will use up-to-date values and size the table correctly.  Since this adds the cost of an extra run through each row in the table, I also added a prop to FixedDataTable called hasDynamicRowHeight so it will only loop if you tell it to.  It could be smarter to figure this out on its own or not loop through this again later, but since my use case for dynamic rows has n =< 5 I didn't investigate further.